### PR TITLE
Redux support added to GameEngine, tests, Console, and Project

### DIFF
--- a/Console/Console.csproj
+++ b/Console/Console.csproj
@@ -11,4 +11,9 @@
 	<ItemGroup>
 		<PackageReference Include="CommandLineParser" Version="2.8.0"/>
 	</ItemGroup>
+	<ItemGroup>
+    	<PackageReference Include="com.csutil.cscore" Version="*" />
+    	<!-- https://www.nuget.org/packages/Newtonsoft.Json -->
+    	<PackageReference Include="Newtonsoft.Json" Version="*" />
+  </ItemGroup>
 </Project>

--- a/Console/Program.cs
+++ b/Console/Program.cs
@@ -1,5 +1,7 @@
 ﻿using System.Text;
 using CommandLine;
+using com.csutil.model.immutable;
+using com.heynow.games;
 
 Console.OutputEncoding = System.Text.Encoding.UTF8;
 Console.ResetColor();
@@ -29,7 +31,9 @@ class Runtime {
     }
 
     public Runtime() {
-        game.SetSize(23);
+        game.GetStore().AddStateChangeListener(state => state.size, (size) => {
+            Console.WriteLine($"Size is now {size}");
+        });
 
         while (true) {
             Console.ForegroundColor = ConsoleColor.DarkGreen;
@@ -45,16 +49,15 @@ class Runtime {
                 Console.ResetColor();
                 break;
             } else {
-                var result = Parser.Default.ParseArguments<Inspect>(splitter(input))
+                var result = Parser.Default.ParseArguments<Grow, Shrink>(splitter(input))
                     .MapResult(
-                        (Inspect o) => {
-                            switch (o.noun!) {
-                                case "size": {
-                                        return $"{game.Size}";
-                                    }
-                                default:
-                                    return "unknown inspect noun.";
-                            }
+                        (Grow o) => {
+                            game.Grow();
+                            return "Grow() called.";
+                        },
+                        (Shrink o) => {
+                            game.Shrink();
+                            return "Shrink() called.";
                         },
                         errors => "error");
                 Console.WriteLine(result);
@@ -62,9 +65,8 @@ class Runtime {
         }
     }
 
-    [Verb("inspect", HelpText = "inspect an object")]
-    public class Inspect {
-        [Value(0, HelpText = "'size'", Required = true)]
-        public string? noun { get; set; }
-    }
+    [Verb("grow", HelpText = "grow an object")]
+    public class Grow { }
+    [Verb("shrink", HelpText = "shrink an object")]
+    public class Shrink { }
 };

--- a/GameEngine/src/GameEngine.cs
+++ b/GameEngine/src/GameEngine.cs
@@ -1,5 +1,60 @@
-﻿public class GameEngine {
-    public int Size { get; internal set; } = 0;
+﻿using com.csutil.model.immutable;
 
-    public void SetSize(int s) => Size = s;
+namespace com.heynow.games {
+    public class GameEngine {
+        public class State {
+            public readonly int size;
+
+            public State(int size = 1) {
+                this.size = size;
+            }
+        }
+
+        private State state;
+        public DataStore<State> store;
+
+        public class Actions {
+            public class ChangeSize : Actions { public int newSize; }
+            public class Grow : Actions { }
+            public class Shrink : Actions { }
+        }
+
+        public static class Reducers {
+            // The most outer reducer is public to be passed into the store:
+            public static State ReduceState(State previousState, object action) {
+                if (action is Actions.ChangeSize) {
+                    bool changed = false;
+                    var newSize = previousState.size.Mutate(action, ReduceSize, ref changed);
+                    if (changed) { return new State(newSize); }
+                } else if (action is Actions.Grow && previousState.size < 5) {
+                    return new State(previousState.size + 1);
+                } else if (action is Actions.Shrink && previousState.size > 1) {
+                    return new State(previousState.size - 1);
+                }
+                return previousState;
+            }
+
+            private static int ReduceSize(int oldSize, object action) {
+                if (action is Actions.ChangeSize s) { return s.newSize; }
+                return oldSize;
+            }
+        }
+
+        public GameEngine() {
+            state = new State();
+            store = new DataStore<State>(Reducers.ReduceState, state);
+        }
+
+        public DataStore<State> GetStore() => store;
+
+        public void Grow() {
+            var size = state.size;
+            store.Dispatch(new Actions.Grow());
+        }
+
+        public void Shrink() {
+            var size = state.size;
+            store.Dispatch(new Actions.Shrink());
+        }
+    }
 }

--- a/GameEngine/src/GameEngine.csproj
+++ b/GameEngine/src/GameEngine.csproj
@@ -4,4 +4,10 @@
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="com.csutil.cscore" Version="*" />
+    <!-- https://www.nuget.org/packages/Newtonsoft.Json -->
+    <PackageReference Include="Newtonsoft.Json" Version="*" />
+  </ItemGroup>
+  
 </Project>

--- a/GameEngine/test/GameEngineTests.cs
+++ b/GameEngine/test/GameEngineTests.cs
@@ -1,16 +1,61 @@
 using Xunit;
-
+using com.csutil.model.immutable;
+using com.heynow.games;
 namespace test;
 
-public class UnitTestCore
-{
+public class UnitTestCore {
     [Fact]
-    public void TestSize()
-    {
-        var core = new GameEngine();
-        Assert.Equal(0, core.Size);
+    public void TestState() {
+        var data = new GameEngine.State();
+        var size = 0;
+        var store = new DataStore<GameEngine.State>(GameEngine.Reducers.ReduceState, data);
+        store.AddStateChangeListener(state => state.size, (s) => {
+            size = s;
+        });
+        Assert.Equal(1, size);
 
-        core.SetSize(5);
-        Assert.Equal(5, core.Size);
+        store.Dispatch(new GameEngine.Actions.ChangeSize() { newSize = 5 });
+        Assert.Equal(5, size);
+    }
+
+    [Fact]
+    public void TestGameInstance() {
+        var ge = new GameEngine();
+
+        var size = 0;
+        ge.GetStore().AddStateChangeListener(state => state.size, (s) => {
+            size = s;
+        });
+
+        ge.GetStore().Dispatch(new GameEngine.Actions.ChangeSize() { newSize = 23 });
+        Assert.Equal(23, size);
+    }
+
+    [Fact]
+    public void TestShrinkAndGrow() {
+        var ge = new GameEngine();
+
+        var size = 0;
+        ge.GetStore().AddStateChangeListener(state => state.size, (s) => {
+            size = s;
+        });
+
+        ge.Grow();
+        Assert.Equal(2, size);
+        ge.Shrink();
+        Assert.Equal(1, size);
+    }
+
+    [Fact]
+    public void TestShrinkTooMuch() {
+        var ge = new GameEngine();
+
+        var size = 0;
+        ge.GetStore().AddStateChangeListener(state => state.size, (s) => {
+            size = s;
+        });
+
+        ge.Shrink();
+        Assert.Equal(1, size);
     }
 }

--- a/Project/Assets/Scenes/SampleScene.unity
+++ b/Project/Assets/Scenes/SampleScene.unity
@@ -190,6 +190,50 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &700536519
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 700536521}
+  - component: {fileID: 700536520}
+  m_Layer: 0
+  m_Name: GameEngine
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &700536520
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 700536519}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe947bc1ead244eb3afa98dd4f2ec3ef, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &700536521
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 700536519}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &705507993
 GameObject:
   m_ObjectHideFlags: 0
@@ -815,7 +859,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d3f78a381c90e4969ab6e58aa1785335, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  capsule: {fileID: 1944667686}
 --- !u!1 &1581913805
 GameObject:
   m_ObjectHideFlags: 0

--- a/Project/Assets/_Project/Plugins.meta
+++ b/Project/Assets/_Project/Plugins.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: abe9f3e732faa4ac3a7c326e3d8cfae4
+guid: d7970d4c698af44feaa78bc78f8c7ad3
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/Project/Assets/_Project/Scripts/ButtonManagerMB.cs
+++ b/Project/Assets/_Project/Scripts/ButtonManagerMB.cs
@@ -2,13 +2,9 @@ using UnityEngine;
 
 namespace com.heynow.project {
     public class ButtonManagerMB : MonoBehaviour {
-        public CapsuleMB capsule;
-        public void OnGrowButtonPress() {
-            capsule.ChangeSize(1);
-        }
+        public GameEngineMB gmb;
+        public void OnGrowButtonPress() => gmb.Game.Grow();
 
-        public void OnShrinkButtonPress() {
-            capsule.ChangeSize(-1);
-        }
+        public void OnShrinkButtonPress() => gmb.Game.Shrink();
     }
 }

--- a/Project/Assets/_Project/Scripts/ButtonManagerMB.cs
+++ b/Project/Assets/_Project/Scripts/ButtonManagerMB.cs
@@ -1,11 +1,14 @@
 using UnityEngine;
-public class ButtonManagerMB : MonoBehaviour {
-    public CapsuleMB capsule;
-    public void OnGrowButtonPress() {
-        capsule.ChangeSize(1);
-    }
 
-    public void OnShrinkButtonPress() {
-        capsule.ChangeSize(-1);
+namespace com.heynow.project {
+    public class ButtonManagerMB : MonoBehaviour {
+        public CapsuleMB capsule;
+        public void OnGrowButtonPress() {
+            capsule.ChangeSize(1);
+        }
+
+        public void OnShrinkButtonPress() {
+            capsule.ChangeSize(-1);
+        }
     }
 }

--- a/Project/Assets/_Project/Scripts/CapsuleMB.cs
+++ b/Project/Assets/_Project/Scripts/CapsuleMB.cs
@@ -1,26 +1,17 @@
 using UnityEngine;
+using com.csutil.model.immutable;
 
 namespace com.heynow.project {
     public class CapsuleMB : MonoBehaviour {
-        private GameEngine game = new GameEngine();
+        public GameEngineMB gmb;
 
         void Start() {
-            setSize(1);
+            gmb.Game.GetStore().AddStateChangeListener(state => state.size, (size) => {
+                transform.localScale = new Vector3(size, size, size);
+            });
         }
 
         void Update() {
-        }
-
-        private void setSize(int newSize) {
-            if (newSize >= 1 && newSize <= 10) {
-                game.SetSize(newSize);
-                var size = game.Size;
-                transform.localScale = new Vector3(size, size, size);
-            }
-        }
-
-        public void ChangeSize(int delta) {
-            setSize(game.Size + delta);
         }
     }
 }

--- a/Project/Assets/_Project/Scripts/CapsuleMB.cs
+++ b/Project/Assets/_Project/Scripts/CapsuleMB.cs
@@ -1,24 +1,26 @@
 using UnityEngine;
 
-public class CapsuleMB : MonoBehaviour {
-    private GameEngine game = new GameEngine();
+namespace com.heynow.project {
+    public class CapsuleMB : MonoBehaviour {
+        private GameEngine game = new GameEngine();
 
-    void Start() {
-        setSize(1);
-    }
-
-    void Update() {
-    }
-
-    private void setSize(int newSize) {
-        if (newSize >= 1 && newSize <= 10) {
-            game.SetSize(newSize);
-            var size = game.Size;
-            transform.localScale = new Vector3(size, size, size);
+        void Start() {
+            setSize(1);
         }
-    }
 
-    public void ChangeSize(int delta) {
-        setSize(game.Size + delta);
+        void Update() {
+        }
+
+        private void setSize(int newSize) {
+            if (newSize >= 1 && newSize <= 10) {
+                game.SetSize(newSize);
+                var size = game.Size;
+                transform.localScale = new Vector3(size, size, size);
+            }
+        }
+
+        public void ChangeSize(int delta) {
+            setSize(game.Size + delta);
+        }
     }
 }

--- a/Project/Assets/_Project/Scripts/GameEngineMB.cs
+++ b/Project/Assets/_Project/Scripts/GameEngineMB.cs
@@ -1,0 +1,17 @@
+using UnityEngine;
+using com.heynow.games;
+
+namespace com.heynow.project {
+    public class GameEngineMB : MonoBehaviour {
+        public GameEngine Game;
+
+        // Start is called before the first frame update
+        void Start() {
+            Game = new GameEngine();
+        }
+
+        // Update is called once per frame
+        void Update() {
+        }
+    }
+}

--- a/Project/Assets/_Project/Scripts/GameEngineMB.cs.meta
+++ b/Project/Assets/_Project/Scripts/GameEngineMB.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fe947bc1ead244eb3afa98dd4f2ec3ef
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Project/Packages/manifest.json
+++ b/Project/Packages/manifest.json
@@ -1,5 +1,7 @@
 {
   "dependencies": {
+    "com.csutil.cscore": "https://github.com/cs-util-com/cscore.git?path=CsCore/PlainNetClassLib/src/Plugins",
+    "com.csutil.cscore.unity": "https://github.com/cs-util-com/cscore.git?path=CsCore/CsCoreUnity/Plugins",
     "com.unity.collab-proxy": "1.15.13",
     "com.unity.feature.development": "1.0.1",
     "com.unity.ide.rider": "3.0.12",

--- a/Project/Packages/packages-lock.json
+++ b/Project/Packages/packages-lock.json
@@ -1,5 +1,21 @@
 {
   "dependencies": {
+    "com.csutil.cscore": {
+      "version": "https://github.com/cs-util-com/cscore.git?path=CsCore/PlainNetClassLib/src/Plugins",
+      "depth": 0,
+      "source": "git",
+      "dependencies": {
+        "com.unity.nuget.newtonsoft-json": "2.0.2"
+      },
+      "hash": "03ffa9d6ad9ae709557fd42872a7ee8eac20545a"
+    },
+    "com.csutil.cscore.unity": {
+      "version": "https://github.com/cs-util-com/cscore.git?path=CsCore/CsCoreUnity/Plugins",
+      "depth": 0,
+      "source": "git",
+      "dependencies": {},
+      "hash": "03ffa9d6ad9ae709557fd42872a7ee8eac20545a"
+    },
     "com.unity.collab-proxy": {
       "version": "1.15.13",
       "depth": 0,
@@ -58,6 +74,13 @@
     "com.unity.ide.vscode": {
       "version": "1.2.5",
       "depth": 0,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.nuget.newtonsoft-json": {
+      "version": "2.0.2",
+      "depth": 1,
       "source": "registry",
       "dependencies": {},
       "url": "https://packages.unity.com"


### PR DESCRIPTION
Using cscore based Redux-like [Immutable Datastore](https://github.com/cs-util-com/cscore#immutable-datastore) to handle model, store, actions, and reducers.

Console session:

<img width="492" alt="image" src="https://user-images.githubusercontent.com/1264625/159834378-d9ebeb76-cd7b-4696-b74d-d859f1645929.png">
